### PR TITLE
Fix style not applied due to class name mismatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
   <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 
-<body>
-  <main class="Simulation">
+  <body>
+    <main class="simulation">
     <script src="sketch.js"></script>
   </main>
   <!-- Charger le script principal -->


### PR DESCRIPTION
## Summary
- apply CSS `.simulation` class by using lowercase in `index.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ab5977b648320a1e0328b3e2f66e5